### PR TITLE
feat: add --verbose flag for debugging Native SDK

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,10 @@ struct Cli {
     /// Show demo output with sample data
     #[arg(long)]
     demo: bool,
+
+    /// Show verbose output for debugging
+    #[arg(long, short)]
+    verbose: bool,
 }
 
 #[tokio::main]
@@ -25,16 +29,16 @@ async fn main() -> Result<()> {
     let stats = if cli.demo {
         demo_stats()
     } else {
-        fetch_stats().await?
+        fetch_stats(cli.verbose).await?
     };
 
     display::render(&stats);
     Ok(())
 }
 
-async fn fetch_stats() -> Result<steam::SteamStats> {
+async fn fetch_stats(verbose: bool) -> Result<steam::SteamStats> {
     // Try Steamworks SDK first, fallback to Web API
-    match NativeSteamClient::try_new() {
+    match NativeSteamClient::try_new(verbose) {
         Some(native) => fetch_native_stats(native).await,
         None => fetch_web_stats().await,
     }


### PR DESCRIPTION
## Summary
Add `--verbose` flag to help debug Native Steam SDK connection issues.

## Changes
- Add `--verbose` / `-v` CLI flag
- Print debug messages when verbose mode is enabled:
  - Steam client path detection
  - Library loading status
  - CreateInterface result
  - CreateSteamPipe result
  - ConnectToGlobalUser result
- Fix Windows registry parsing (handle forward slashes in SteamPath)

## Usage
```bash
steamfetch --verbose
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--verbose` / `-v` command-line flag to enable detailed debug output during application initialization and statistics retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->