### PR TITLE
feat: add config file support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,6 +177,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +709,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libredox"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -811,6 +842,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,6 +940,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -1099,6 +1147,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1218,7 @@ dependencies = [
  "anyhow",
  "clap",
  "colored",
+ "dirs",
  "futures",
  "libloading",
  "reqwest",
@@ -1169,6 +1227,7 @@ dependencies = [
  "steamworks",
  "thiserror",
  "tokio",
+ "toml",
 ]
 
 [[package]]
@@ -1356,6 +1415,47 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1761,6 +1861,15 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ tokio = { version = "1", features = ["full"] }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
+dirs = "6"
 colored = "2"
 clap = { version = "4", features = ["derive"] }
 thiserror = "2"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,9 +1,59 @@
 use anyhow::{Context, Result};
-use std::env;
+use serde::Deserialize;
+use std::path::PathBuf;
+use std::{env, fs};
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ConfigFile {
+    #[serde(default)]
+    pub api: ApiConfig,
+    #[serde(default)]
+    pub display: DisplayConfig,
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct ApiConfig {
+    pub steam_api_key: Option<String>,
+    pub steam_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct DisplayConfig {
+    #[serde(default = "default_top_games")]
+    pub show_top_games: usize,
+    #[serde(default = "default_true")]
+    pub show_recently_played: bool,
+    #[serde(default = "default_true")]
+    pub show_achievements: bool,
+    #[serde(default = "default_true")]
+    pub show_rarest: bool,
+}
+
+impl Default for DisplayConfig {
+    fn default() -> Self {
+        Self {
+            show_top_games: 5,
+            show_recently_played: true,
+            show_achievements: true,
+            show_rarest: true,
+        }
+    }
+}
+
+fn default_top_games() -> usize {
+    5
+}
+
+fn default_true() -> bool {
+    true
+}
 
 pub struct Config {
     pub api_key: String,
     pub steam_id: String,
+    #[allow(dead_code)]
+    pub display: DisplayConfig,
 }
 
 const API_KEY_HELP: &str = r#"STEAM_API_KEY not set.
@@ -15,6 +65,11 @@ To get your API key:
   4. Copy the key and set it:
 
      export STEAM_API_KEY="your-api-key-here"
+
+Or add to config file (~/.config/steamfetch/config.toml):
+
+     [api]
+     steam_api_key = "your-api-key-here"
 "#;
 
 const STEAM_ID_HELP: &str = r#"STEAM_ID not set.
@@ -26,14 +81,56 @@ To find your Steam ID:
 
      export STEAM_ID="your-steam-id-here"
 
+Or add to config file (~/.config/steamfetch/config.toml):
+
+     [api]
+     steam_id = "your-steam-id-here"
+
 Note: If Steam is running, STEAM_ID is auto-detected and not required.
 "#;
 
 impl Config {
-    pub fn from_env() -> Result<Self> {
-        let api_key = env::var("STEAM_API_KEY").context(API_KEY_HELP)?;
-        let steam_id = env::var("STEAM_ID").context(STEAM_ID_HELP)?;
+    pub fn load(config_path: Option<PathBuf>) -> Result<Self> {
+        let config_file = load_config_file(config_path)?;
 
-        Ok(Self { api_key, steam_id })
+        // Environment variables take precedence over config file
+        let api_key = env::var("STEAM_API_KEY")
+            .ok()
+            .or(config_file.api.steam_api_key)
+            .context(API_KEY_HELP)?;
+
+        let steam_id = env::var("STEAM_ID")
+            .ok()
+            .or(config_file.api.steam_id)
+            .context(STEAM_ID_HELP)?;
+
+        Ok(Self {
+            api_key,
+            steam_id,
+            display: config_file.display,
+        })
     }
+}
+
+fn load_config_file(custom_path: Option<PathBuf>) -> Result<ConfigFile> {
+    let path = custom_path.or_else(default_config_path);
+
+    match path {
+        Some(p) if p.exists() => {
+            let content = fs::read_to_string(&p)
+                .with_context(|| format!("Failed to read config file: {}", p.display()))?;
+            toml::from_str(&content)
+                .with_context(|| format!("Failed to parse config file: {}", p.display()))
+        }
+        _ => Ok(ConfigFile::default()),
+    }
+}
+
+fn default_config_path() -> Option<PathBuf> {
+    dirs::config_dir().map(|p| p.join("steamfetch").join("config.toml"))
+}
+
+/// Returns the default config file path for display purposes
+pub fn config_path() -> Option<PathBuf> {
+    default_config_path()
 }


### PR DESCRIPTION
## Summary
Add support for configuration file at `~/.config/steamfetch/config.toml`

Closes #3

## Features
- Config file at `~/.config/steamfetch/config.toml` (XDG compliant)
- API settings: `steam_api_key`, `steam_id`
- Display settings: `show_top_games`, `show_recently_played`, `show_achievements`, `show_rarest`
- `--config <PATH>` flag for custom config path
- `--config-path` flag to show default config location
- Environment variables take precedence over config file

## Example Config
```toml
[api]
steam_api_key = "YOUR_API_KEY"
steam_id = "YOUR_STEAM_ID"

[display]
show_top_games = 5
show_recently_played = true
show_achievements = true
show_rarest = true
```

## Usage
```bash
# Show config path
steamfetch --config-path

# Use custom config
steamfetch --config /path/to/config.toml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files are now supported for easier setup and management
  * Added CLI option to specify a custom configuration file path
  * Added CLI flag to display the default configuration file location
  * Environment variables continue to take priority over file-based configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->