### PR TITLE
fix: make rarest achievement deterministic and fix shutdown delay

### DIFF
--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1,6 +1,7 @@
 use anyhow::{Context, Result};
 use futures::future::join_all;
 use reqwest::Client;
+use std::time::Duration;
 
 use super::models::{
     AchievementStats, AchievementsResponse, GameStat, GlobalAchievementsResponse,
@@ -18,8 +19,14 @@ pub struct SteamClient {
 
 impl SteamClient {
     pub fn new(api_key: String, steam_id: String) -> Self {
+        let client = Client::builder()
+            .pool_idle_timeout(Duration::from_secs(1))
+            .pool_max_idle_per_host(0)
+            .build()
+            .unwrap_or_else(|_| Client::new());
+
         Self {
-            client: Client::new(),
+            client,
             api_key,
             steam_id,
             verbose: false,
@@ -282,7 +289,7 @@ impl SteamClient {
         let mut total_achieved = 0u32;
         let mut total_possible = 0u32;
         let mut perfect_games = 0u32;
-        let mut rarest: Option<RarestAchievement> = None;
+        let mut rarest_candidates: Vec<RarestAchievement> = Vec::new();
 
         for result in results.into_iter().flatten() {
             total_achieved += result.achieved;
@@ -293,13 +300,18 @@ impl SteamClient {
             }
 
             if let Some(r) = result.rarest {
-                match &rarest {
-                    None => rarest = Some(r),
-                    Some(current) if r.percent < current.percent => rarest = Some(r),
-                    _ => {}
-                }
+                rarest_candidates.push(r);
             }
         }
+
+        // Sort by percent, then by game name, then by achievement name for deterministic results
+        let rarest = rarest_candidates.into_iter().min_by(|a, b| {
+            a.percent
+                .partial_cmp(&b.percent)
+                .unwrap()
+                .then_with(|| a.game.cmp(&b.game))
+                .then_with(|| a.name.cmp(&b.name))
+        });
 
         (total_possible > 0).then_some(AchievementStats {
             total_achieved,


### PR DESCRIPTION
## Summary
- Make rarest achievement selection deterministic by sorting by percent, game name, then achievement name
- Fix slow program exit by configuring HTTP connection pool to close immediately

## Changes
- Collect all rarest candidates and select minimum after sorting
- Set `pool_idle_timeout(1s)` and `pool_max_idle_per_host(0)` on reqwest client

## Fixed Issues
- Rarest achievement displayed differently on each run
- Program hangs for a long time after output is displayed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized HTTP connection pooling configuration to improve resource efficiency and reduce idle connection memory overhead.
  
* **Improvements**
  * Enhanced achievement rarest calculations with improved deterministic ranking methodology, ensuring consistent and predictable results across all sessions by ranking achievements based on performance metrics, associated game names, and unique achievement identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->