### PR TITLE
fix: add rpath for Homebrew lib directory to resolve libsteam_api

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,15 @@
 fn main() {
     // Set rpath so the binary looks for Steam API library in the same directory
+    // and in ../lib/steamfetch/ (for Homebrew: bin/ -> lib/steamfetch/)
     #[cfg(target_os = "linux")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../lib/steamfetch");
+    }
 
     #[cfg(target_os = "macos")]
-    println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
+    {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path");
+        println!("cargo:rustc-link-arg=-Wl,-rpath,@executable_path/../lib/steamfetch");
+    }
 }


### PR DESCRIPTION
## Summary
- Add `@executable_path/../lib/steamfetch` rpath so the binary can find `libsteam_api.dylib` when installed via Homebrew (`bin/` -> `lib/steamfetch/`)
- Existing `@executable_path` / `$ORIGIN` rpath is preserved for `install.sh` and local builds
- Companion PR: https://github.com/unhappychoice/homebrew-tap — installs `libsteam_api` to `lib/steamfetch/`

Fixes: `dyld: Library not loaded: @loader_path/libsteam_api.dylib` on macOS when installed via Homebrew

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration for Linux and macOS to enhance how the application discovers and locates Steam API dependencies at runtime. This update enables more flexible deployment options, supports a broader range of installation configurations, and significantly improves application portability across diverse system environments and distributions while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->