### PR TITLE
docs: redesign README hero and enable Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
-      - name: Test
-        run: cargo test --all-features
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage report
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
+          fail_ci_if_error: false
 
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -1,14 +1,19 @@
-# steamfetch
+<p align="center">
+  <img src="docs/screenshot.png" alt="steamfetch" width="820">
+</p>
 
-[![CI](https://github.com/unhappychoice/steamfetch/actions/workflows/ci.yml/badge.svg)](https://github.com/unhappychoice/steamfetch/actions/workflows/ci.yml)
-[![crates.io](https://img.shields.io/crates/v/steamfetch.svg)](https://crates.io/crates/steamfetch)
-[![License: ISC](https://img.shields.io/badge/License-ISC-blue.svg)](https://opensource.org/licenses/ISC)
+<p align="center">
+  <a href="https://crates.io/crates/steamfetch"><img src="https://img.shields.io/crates/v/steamfetch.svg?style=flat-square&color=E06B4B" alt="crates.io"></a>
+  <a href="https://github.com/unhappychoice/steamfetch/releases"><img src="https://img.shields.io/github/v/release/unhappychoice/steamfetch?style=flat-square&color=E0C14B&label=release" alt="release"></a>
+  <a href="https://github.com/unhappychoice/steamfetch/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/unhappychoice/steamfetch/ci.yml?branch=main&style=flat-square&label=CI" alt="CI"></a>
+  <a href="https://codecov.io/gh/unhappychoice/steamfetch"><img src="https://img.shields.io/codecov/c/github/unhappychoice/steamfetch?style=flat-square" alt="codecov"></a>
+  <a href="https://github.com/unhappychoice/steamfetch/blob/main/LICENSE"><img src="https://img.shields.io/crates/l/steamfetch.svg?style=flat-square" alt="license"></a>
+</p>
 
-neofetch for Steam - Display your Steam stats in terminal with style.
-
-## Screenshot
-
-![screenshot](docs/screenshot.png)
+<p align="center">
+  <strong>neofetch for Steam — Display your Steam stats in terminal with style.</strong><br>
+  <sub>Account level, playtime, achievements, top games, and rarest unlocks — all rendered with SteamOS-flavored ASCII art.</sub>
+</p>
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Redesign README hero with a centered screenshot and flat-square badges (crates.io / release / CI / codecov / license), matching the gitlogue style
- Switch CI test job to `cargo-llvm-cov` and upload `lcov.info` via `codecov/codecov-action@v4`

## Test plan
- [x] `cargo check`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Verify the rendered hero on GitHub
- [ ] Confirm coverage upload succeeds in CI (requires `CODECOV_TOKEN` secret if Codecov rejects tokenless uploads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)