### PR TITLE
test: improve line coverage

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -282,6 +282,31 @@ mod tests {
         }
 
         #[test]
+        fn test_save_default_cache_persists_empty_file() {
+            let _guard = lock_env();
+            let root = unique_cache_root("empty-save");
+            let _scope = EnvScope::set(&root);
+
+            AchievementCache::default().save();
+
+            let path = cache_path().unwrap();
+            assert!(path.exists(), "save() must create an empty cache file");
+            let json = std::fs::read_to_string(&path).expect("empty cache should be readable");
+            let value: serde_json::Value =
+                serde_json::from_str(&json).expect("empty cache should be valid JSON");
+            let games = value
+                .get("games")
+                .and_then(serde_json::Value::as_object)
+                .expect("empty cache JSON should contain a games object");
+            assert!(games.is_empty());
+
+            let loaded = AchievementCache::load();
+            assert!(loaded.get(1, 0).is_none());
+
+            let _ = std::fs::remove_dir_all(&root);
+        }
+
+        #[test]
         fn test_envscope_drop_restores_previous_xdg_cache_home() {
             // Sibling tests start with XDG_CACHE_HOME unset, so EnvScope::Drop
             // only ever runs its `None => env::remove_var(...)` arm. Pre-set

--- a/src/config.rs
+++ b/src/config.rs
@@ -607,6 +607,30 @@ steam_api_key = "file-key"
         }
 
         #[test]
+        fn test_load_config_file_none_uses_default_config_path() {
+            // With no custom path, load_config_file should resolve the default
+            // config path from XDG_CONFIG_HOME and create the default file
+            // there when it does not already exist.
+            let _guard = lock_env();
+            let root = unique_path("xdg-config-home");
+            let _xdg = EnvScope::set("XDG_CONFIG_HOME", &root.to_string_lossy());
+
+            let cfg = load_config_file(None).expect("missing default config should be created");
+            assert!(cfg.api.steam_api_key.is_none());
+            assert!(cfg.api.steam_id.is_none());
+            assert_eq!(cfg.display.show_top_games, 5);
+            assert!(cfg.display.show_recently_played);
+
+            let path = root.join("steamfetch/config.toml");
+            assert!(path.exists());
+            assert_eq!(config_path().as_deref(), Some(path.as_path()));
+
+            let _ = fs::remove_file(&path);
+            let _ = fs::remove_dir(path.parent().unwrap());
+            let _ = fs::remove_dir(&root);
+        }
+
+        #[test]
         fn test_envscope_drop_restores_previous_value_when_present() {
             // The other tests in this module always start with the env var
             // unset, so EnvScope::Drop's `None` arm is the only one ever hit.

--- a/src/display.rs
+++ b/src/display.rs
@@ -1263,6 +1263,25 @@ mod tests {
         }
 
         #[test]
+        fn test_render_with_image_falls_back_when_avatar_download_fails() {
+            let _guard = lock_env();
+            let root = unique_cache_root("download-fail");
+            let _scope = EnvScope::set(&root);
+
+            let mut stats = make_minimal_stats();
+            stats.username = "downloadfail".to_string();
+            stats.avatar_url = Some("http://127.0.0.1:1/missing.png".to_string());
+
+            let config = ImageConfig {
+                enabled: true,
+                protocol: ImageProtocol::Sixel,
+            };
+            run_async(render(&stats, &config));
+
+            let _ = std::fs::remove_dir_all(&root);
+        }
+
+        #[test]
         fn test_envscope_drop_restores_previous_xdg_cache_home() {
             // Sibling tests in this submodule run with XDG_CACHE_HOME unset,
             // so EnvScope::Drop's `None => env::remove_var(...)` arm dominates

--- a/src/display.rs
+++ b/src/display.rs
@@ -1315,6 +1315,8 @@ mod tests {
             // uncovered. Pre-set the variable before constructing an EnvScope
             // so prev = Some(v), forcing Drop to take the restore branch.
             let _guard = lock_env();
+            let outer_root = unique_cache_root("envscope-restore-outer");
+            let _outer_scope = EnvScope::set(&outer_root);
             let outer_prev = env::var("XDG_CACHE_HOME").ok();
 
             let sentinel_root = unique_cache_root("envscope-restore-sentinel");

--- a/src/display.rs
+++ b/src/display.rs
@@ -1062,6 +1062,32 @@ mod tests {
     }
 
     #[test]
+    fn test_build_info_lines_truncates_rarest_section_for_narrow_width() {
+        let mut stats = make_minimal_stats();
+        stats.achievement_stats = Some(AchievementStats {
+            total_achieved: 8,
+            total_possible: 10,
+            perfect_games: 1,
+            rarest: Some(RarestAchievement {
+                name: "A Very Long Achievement Name".to_string(),
+                game: "A Very Long Game Title".to_string(),
+                percent: 12.3,
+            }),
+        });
+
+        let lines = build_info_lines(&stats, 20);
+        let text = lines_text(&lines);
+        let rarest_line = text.lines().find(|line| line.contains("Rarest")).unwrap();
+        let game_line = text.lines().find(|line| line.contains("in ")).unwrap();
+
+        assert!(rarest_line.contains("..."));
+        assert!(rarest_line.contains("12.3%"));
+        assert!(game_line.contains("..."));
+        assert!(!rarest_line.contains("Achievement Name"));
+        assert!(!game_line.contains("Game Title"));
+    }
+
+    #[test]
     fn test_build_info_lines_with_recently_played_adds_section() {
         let mut stats = make_minimal_stats();
         stats.recently_played = vec![GameStat {

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -536,6 +536,17 @@ mod tests {
         }
 
         #[test]
+        fn test_print_sixel_errors_when_rgba_buffer_is_too_short() {
+            let err = print_sixel(&[], 1, 1).expect_err("empty RGBA buffer should fail");
+            assert_eq!(err.kind(), io::ErrorKind::Other);
+
+            let err = print_sixel(&[255, 0, 0], 1, 1)
+                .expect_err("RGB-only buffer should fail without alpha");
+            assert_eq!(err.kind(), io::ErrorKind::Other);
+            assert!(!err.to_string().is_empty());
+        }
+
+        #[test]
         fn test_print_image_and_rewind_kitty_returns_input_rows() {
             let img = make_test_image(8, 8);
             let rows = print_image_and_rewind(&img, &ImageProtocol::Kitty, 4, 3);

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -1133,6 +1133,33 @@ mod tests {
         }
 
         #[test]
+        fn test_envscope_drop_restores_previous_xdg_cache_home() {
+            let _guard = lock_env();
+            let outer_prev = env::var("XDG_CACHE_HOME").ok();
+            let sentinel_root = unique_cache_root("envscope-restore-sentinel");
+            env::set_var("XDG_CACHE_HOME", &sentinel_root);
+
+            let scoped_root = unique_cache_root("envscope-restore-scoped");
+            {
+                let _scope = EnvScope::set(&scoped_root);
+                assert_eq!(
+                    env::var("XDG_CACHE_HOME").unwrap(),
+                    scoped_root.to_string_lossy(),
+                );
+            }
+
+            assert_eq!(
+                env::var("XDG_CACHE_HOME").unwrap(),
+                sentinel_root.to_string_lossy(),
+            );
+
+            match outer_prev {
+                Some(v) => env::set_var("XDG_CACHE_HOME", v),
+                None => env::remove_var("XDG_CACHE_HOME"),
+            }
+        }
+
+        #[test]
         fn test_load_cached_or_download_fetches_and_saves_when_cache_miss() {
             // Empty cache + reachable HTTP server returning a real PNG →
             // exercises the `download_image(...).await?` and

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -520,6 +520,116 @@ mod tests {
         let _ = query_cell_size_escape();
     }
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_query_cell_size_escape_parses_terminal_response() {
+        use std::io::Read;
+        use std::os::fd::FromRawFd;
+        use std::os::unix::process::CommandExt;
+        use std::process::{Command, Stdio};
+
+        let mut master = -1;
+        let mut slave = -1;
+        let size = libc::winsize {
+            ws_row: 24,
+            ws_col: 80,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        let opened = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &size,
+            )
+        };
+        assert_eq!(opened, 0, "openpty should create a pseudo terminal");
+
+        let mut pipe_fds = [-1, -1];
+        assert_eq!(
+            unsafe { libc::pipe(pipe_fds.as_mut_ptr()) },
+            0,
+            "pipe should be created"
+        );
+
+        let mut child = unsafe {
+            let mut command = Command::new(std::env::current_exe().expect("current test binary"));
+            command
+                .arg("--exact")
+                .arg("image_display::tests::query_cell_size_escape_child_process")
+                .arg("--nocapture")
+                .env(
+                    "STEAMFETCH_QUERY_CELL_SIZE_RESULT_FD",
+                    pipe_fds[1].to_string(),
+                )
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .pre_exec(move || {
+                    if libc::setsid() < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    if libc::ioctl(slave, libc::TIOCSCTTY, 0) < 0 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            command.spawn().expect("child test process should spawn")
+        };
+
+        unsafe {
+            libc::close(slave);
+            libc::close(pipe_fds[1]);
+        }
+
+        let mut query = [0u8; 16];
+        let n = unsafe { libc::read(master, query.as_mut_ptr() as *mut _, query.len()) };
+        assert!(n > 0, "child should write the terminal query");
+        assert!(std::str::from_utf8(&query[..n as usize])
+            .expect("query should be utf8")
+            .contains("\x1b[14t"));
+
+        let response = b"\x1b[4;480;800t";
+        assert_eq!(
+            unsafe { libc::write(master, response.as_ptr() as *const _, response.len()) },
+            response.len() as isize,
+            "terminal response should be written"
+        );
+
+        let mut result = String::new();
+        let mut pipe = unsafe { std::fs::File::from_raw_fd(pipe_fds[0]) };
+        pipe.read_to_string(&mut result)
+            .expect("child result should be readable");
+
+        unsafe {
+            libc::close(master);
+        }
+        let status = child.wait().expect("child test process should exit");
+
+        assert!(status.success(), "child should exit normally");
+        assert_eq!(result, "10,20");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn query_cell_size_escape_child_process() {
+        use std::io::Write;
+        use std::os::fd::FromRawFd;
+
+        let Ok(fd) = std::env::var("STEAMFETCH_QUERY_CELL_SIZE_RESULT_FD") else {
+            return;
+        };
+        let fd: i32 = fd.parse().expect("result fd should be an integer");
+        let result = query_cell_size_escape()
+            .map(|(w, h)| format!("{},{}", w, h))
+            .unwrap_or_else(|| "none".to_string());
+        let mut pipe = unsafe { std::fs::File::from_raw_fd(fd) };
+        pipe.write_all(result.as_bytes())
+            .expect("result should be written");
+    }
+
     #[cfg(unix)]
     #[test]
     fn test_query_cell_size_uses_default_without_terminal_size() {

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -523,6 +523,19 @@ mod tests {
     #[cfg(target_os = "linux")]
     #[test]
     fn test_query_cell_size_escape_parses_terminal_response() {
+        let result = query_cell_size_escape_result_from_response(b"\x1b[4;480;800t");
+        assert_eq!(result, "10,20");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_query_cell_size_escape_returns_none_for_zero_pixel_response() {
+        let result = query_cell_size_escape_result_from_response(b"\x1b[4;0;800t");
+        assert_eq!(result, "none");
+    }
+
+    #[cfg(target_os = "linux")]
+    fn query_cell_size_escape_result_from_response(response: &[u8]) -> String {
         use std::io::Read;
         use std::os::fd::FromRawFd;
         use std::os::unix::process::CommandExt;
@@ -591,7 +604,6 @@ mod tests {
             .expect("query should be utf8")
             .contains("\x1b[14t"));
 
-        let response = b"\x1b[4;480;800t";
         assert_eq!(
             unsafe { libc::write(master, response.as_ptr() as *const _, response.len()) },
             response.len() as isize,
@@ -609,7 +621,7 @@ mod tests {
         let status = child.wait().expect("child test process should exit");
 
         assert!(status.success(), "child should exit normally");
-        assert_eq!(result, "10,20");
+        result
     }
 
     #[cfg(target_os = "linux")]

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -536,6 +536,13 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn test_query_cell_size_escape_returns_none_without_response() {
+        let result = query_cell_size_escape_result_from_response(b"");
+        assert_eq!(result, "none");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn test_query_cell_size_uses_escape_fallback_when_ioctl_has_no_pixels() {
         let result = query_cell_size_result_from_response(b"\x1b[4;480;800t", true);
         assert_eq!(result, "10,20");

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -535,7 +535,19 @@ mod tests {
     }
 
     #[cfg(target_os = "linux")]
+    #[test]
+    fn test_query_cell_size_uses_escape_fallback_when_ioctl_has_no_pixels() {
+        let result = query_cell_size_result_from_response(b"\x1b[4;480;800t", true);
+        assert_eq!(result, "10,20");
+    }
+
+    #[cfg(target_os = "linux")]
     fn query_cell_size_escape_result_from_response(response: &[u8]) -> String {
+        query_cell_size_result_from_response(response, false)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn query_cell_size_result_from_response(response: &[u8], use_query_cell_size: bool) -> String {
         use std::io::Read;
         use std::os::fd::FromRawFd;
         use std::os::unix::process::CommandExt;
@@ -576,6 +588,10 @@ mod tests {
                 .env(
                     "STEAMFETCH_QUERY_CELL_SIZE_RESULT_FD",
                     pipe_fds[1].to_string(),
+                )
+                .env(
+                    "STEAMFETCH_QUERY_CELL_SIZE_USE_WRAPPER",
+                    if use_query_cell_size { "1" } else { "0" },
                 )
                 .stdin(Stdio::null())
                 .stdout(Stdio::null())
@@ -634,9 +650,17 @@ mod tests {
             return;
         };
         let fd: i32 = fd.parse().expect("result fd should be an integer");
-        let result = query_cell_size_escape()
-            .map(|(w, h)| format!("{},{}", w, h))
-            .unwrap_or_else(|| "none".to_string());
+        let result = if std::env::var("STEAMFETCH_QUERY_CELL_SIZE_USE_WRAPPER")
+            .ok()
+            .as_deref()
+            == Some("1")
+        {
+            Some(query_cell_size())
+        } else {
+            query_cell_size_escape()
+        }
+        .map(|(w, h)| format!("{},{}", w, h))
+        .unwrap_or_else(|| "none".to_string());
         let mut pipe = unsafe { std::fs::File::from_raw_fd(fd) };
         pipe.write_all(result.as_bytes())
             .expect("result should be written");

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -543,6 +543,19 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     #[test]
+    fn test_query_cell_size_escape_returns_none_when_tty_size_has_no_rows() {
+        let size = libc::winsize {
+            ws_row: 0,
+            ws_col: 80,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        let result = query_cell_size_result_from_response_with_size(b"", false, size, false);
+        assert_eq!(result, "none");
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
     fn test_query_cell_size_uses_escape_fallback_when_ioctl_has_no_pixels() {
         let result = query_cell_size_result_from_response(b"\x1b[4;480;800t", true);
         assert_eq!(result, "10,20");
@@ -555,6 +568,22 @@ mod tests {
 
     #[cfg(target_os = "linux")]
     fn query_cell_size_result_from_response(response: &[u8], use_query_cell_size: bool) -> String {
+        let size = libc::winsize {
+            ws_row: 24,
+            ws_col: 80,
+            ws_xpixel: 0,
+            ws_ypixel: 0,
+        };
+        query_cell_size_result_from_response_with_size(response, use_query_cell_size, size, true)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn query_cell_size_result_from_response_with_size(
+        response: &[u8],
+        use_query_cell_size: bool,
+        size: libc::winsize,
+        expect_query: bool,
+    ) -> String {
         use std::io::Read;
         use std::os::fd::FromRawFd;
         use std::os::unix::process::CommandExt;
@@ -562,12 +591,6 @@ mod tests {
 
         let mut master = -1;
         let mut slave = -1;
-        let size = libc::winsize {
-            ws_row: 24,
-            ws_col: 80,
-            ws_xpixel: 0,
-            ws_ypixel: 0,
-        };
         let opened = unsafe {
             libc::openpty(
                 &mut master,
@@ -620,18 +643,20 @@ mod tests {
             libc::close(pipe_fds[1]);
         }
 
-        let mut query = [0u8; 16];
-        let n = unsafe { libc::read(master, query.as_mut_ptr() as *mut _, query.len()) };
-        assert!(n > 0, "child should write the terminal query");
-        assert!(std::str::from_utf8(&query[..n as usize])
-            .expect("query should be utf8")
-            .contains("\x1b[14t"));
+        if expect_query {
+            let mut query = [0u8; 16];
+            let n = unsafe { libc::read(master, query.as_mut_ptr() as *mut _, query.len()) };
+            assert!(n > 0, "child should write the terminal query");
+            assert!(std::str::from_utf8(&query[..n as usize])
+                .expect("query should be utf8")
+                .contains("\x1b[14t"));
 
-        assert_eq!(
-            unsafe { libc::write(master, response.as_ptr() as *const _, response.len()) },
-            response.len() as isize,
-            "terminal response should be written"
-        );
+            assert_eq!(
+                unsafe { libc::write(master, response.as_ptr() as *const _, response.len()) },
+                response.len() as isize,
+                "terminal response should be written"
+            );
+        }
 
         let mut result = String::new();
         let mut pipe = unsafe { std::fs::File::from_raw_fd(pipe_fds[0]) };

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -1373,6 +1373,8 @@ mod tests {
             // so prev = None, then verify Drop removes the value we set during
             // the scope.
             let _guard = lock_env();
+            let outer_root = unique_cache_root("envscope-none-outer");
+            let _outer_scope = EnvScope::set(&outer_root);
             let outer_prev = env::var("XDG_CACHE_HOME").ok();
             env::remove_var("XDG_CACHE_HOME");
 
@@ -1397,6 +1399,8 @@ mod tests {
         #[test]
         fn test_envscope_drop_restores_previous_xdg_cache_home() {
             let _guard = lock_env();
+            let outer_root = unique_cache_root("envscope-restore-outer");
+            let _outer_scope = EnvScope::set(&outer_root);
             let outer_prev = env::var("XDG_CACHE_HOME").ok();
             let sentinel_root = unique_cache_root("envscope-restore-sentinel");
             env::set_var("XDG_CACHE_HOME", &sentinel_root);

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -730,6 +730,13 @@ mod tests {
             let rows = print_image_and_rewind(&img, &ImageProtocol::Sixel, 4, 3);
             assert_eq!(rows, Some(3));
         }
+
+        #[test]
+        fn test_print_image_and_rewind_returns_none_when_output_fails() {
+            let img = make_test_image(8, 8);
+            let rows = print_image_and_rewind(&img, &ImageProtocol::Sixel, 0, 3);
+            assert_eq!(rows, None);
+        }
     }
 
     mod env_tests {

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -462,6 +462,60 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn test_query_cell_size_ioctl_uses_stdout_pixel_dimensions() {
+        struct StdoutGuard {
+            saved_stdout: i32,
+            master: i32,
+            slave: i32,
+        }
+
+        impl Drop for StdoutGuard {
+            fn drop(&mut self) {
+                unsafe {
+                    libc::dup2(self.saved_stdout, libc::STDOUT_FILENO);
+                    libc::close(self.saved_stdout);
+                    libc::close(self.slave);
+                    libc::close(self.master);
+                }
+            }
+        }
+
+        let mut master = -1;
+        let mut slave = -1;
+        let size = libc::winsize {
+            ws_row: 24,
+            ws_col: 80,
+            ws_xpixel: 800,
+            ws_ypixel: 384,
+        };
+
+        let opened = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null(),
+                &size,
+            )
+        };
+        assert_eq!(opened, 0, "openpty should create a pseudo terminal");
+
+        let saved_stdout = unsafe { libc::dup(libc::STDOUT_FILENO) };
+        assert!(saved_stdout >= 0, "stdout should be duplicated");
+        let _guard = StdoutGuard {
+            saved_stdout,
+            master,
+            slave,
+        };
+
+        unsafe {
+            libc::dup2(slave, libc::STDOUT_FILENO);
+        }
+        assert_eq!(query_cell_size(), (10, 16));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn test_query_cell_size_escape_does_not_panic_without_tty_response() {
         let _ = query_cell_size_escape();
     }

--- a/src/image_display.rs
+++ b/src/image_display.rs
@@ -460,6 +460,18 @@ mod tests {
         let _ = query_cell_size_ioctl();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_query_cell_size_escape_does_not_panic_without_tty_response() {
+        let _ = query_cell_size_escape();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_query_cell_size_uses_default_without_terminal_size() {
+        assert_eq!(query_cell_size(), (10, 20));
+    }
+
     mod print_tests {
         use super::super::*;
         use image::{DynamicImage, ImageBuffer, Rgba};

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,4 +415,101 @@ mod tests {
 
         let _ = std::fs::remove_file(&path);
     }
+
+    #[test]
+    fn test_fetch_web_stats_propagates_client_fetch_error_after_valid_config() {
+        use std::env;
+
+        const PROXY_VARS: &[&str] = &[
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ];
+
+        struct EnvScope {
+            saved: Vec<(&'static str, Option<String>)>,
+        }
+
+        impl EnvScope {
+            fn set_unreachable_proxy(url: &str) -> Self {
+                let saved = PROXY_VARS
+                    .iter()
+                    .map(|&key| {
+                        let prev = env::var(key).ok();
+                        env::remove_var(key);
+                        (key, prev)
+                    })
+                    .collect();
+
+                env::set_var("HTTPS_PROXY", url);
+                env::set_var("https_proxy", url);
+                env::set_var("ALL_PROXY", url);
+                env::set_var("all_proxy", url);
+                env::set_var("NO_PROXY", "127.0.0.1,localhost");
+                env::set_var("no_proxy", "127.0.0.1,localhost");
+
+                Self { saved }
+            }
+        }
+
+        impl Drop for EnvScope {
+            fn drop(&mut self) {
+                for (key, value) in &self.saved {
+                    match value {
+                        Some(v) => env::set_var(key, v),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+
+        let _guard = crate::test_support::lock_env();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+        let _scope = EnvScope::set_unreachable_proxy(&format!("http://{}", addr));
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = env::temp_dir().join(format!(
+            "steamfetch-fetch-web-stats-valid-{}-{}.toml",
+            std::process::id(),
+            nanos
+        ));
+        std::fs::write(
+            &path,
+            r#"
+[api]
+steam_api_key = "test-key"
+steam_id = "76561197960265728"
+"#,
+        )
+        .unwrap();
+
+        let cli = Cli {
+            demo: false,
+            verbose: false,
+            config: Some(path.clone()),
+            config_path: false,
+            timeout: 1,
+            image: false,
+            image_protocol: ImageProtocol::Auto,
+        };
+
+        let err = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt")
+            .block_on(fetch_web_stats(&cli))
+            .expect_err("unreachable proxy should make fetch_stats fail");
+
+        let _ = std::fs::remove_file(&path);
+
+        assert!(err.downcast_ref::<steam::error::SteamApiError>().is_some());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -288,6 +288,31 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_parses_demo_with_image_options() {
+        let cli = Cli::try_parse_from([
+            "steamfetch",
+            "--demo",
+            "--image",
+            "--image-protocol",
+            "iterm",
+            "--timeout",
+            "9",
+            "--config",
+            "/tmp/demo.toml",
+        ])
+        .expect("demo with image options should parse");
+
+        assert!(cli.demo);
+        assert!(cli.image);
+        assert!(matches!(cli.image_protocol, ImageProtocol::Iterm));
+        assert_eq!(cli.timeout, 9);
+        assert_eq!(
+            cli.config.as_deref(),
+            Some(std::path::Path::new("/tmp/demo.toml"))
+        );
+    }
+
+    #[test]
     fn test_cli_parses_config_path_flag() {
         let cli = Cli::try_parse_from(["steamfetch", "--config-path"])
             .expect("--config-path should parse");
@@ -333,6 +358,17 @@ mod tests {
     #[test]
     fn test_cli_rejects_unknown_image_protocol() {
         assert!(Cli::try_parse_from(["steamfetch", "--image-protocol", "bogus"]).is_err());
+    }
+
+    #[test]
+    fn test_cli_rejects_missing_option_values() {
+        for args in [
+            ["steamfetch", "--timeout"],
+            ["steamfetch", "--config"],
+            ["steamfetch", "--image-protocol"],
+        ] {
+            assert!(Cli::try_parse_from(args).is_err());
+        }
     }
 
     #[test]
@@ -562,6 +598,109 @@ steam_id = "76561197960265728"
             Some(v) => env::set_var("ALL_PROXY", v),
             None => env::remove_var("ALL_PROXY"),
         }
+
+        assert!(err.downcast_ref::<steam::error::SteamApiError>().is_some());
+    }
+
+    #[test]
+    fn test_fetch_web_stats_uses_env_credentials_before_client_error() {
+        use std::env;
+
+        const PROXY_VARS: &[&str] = &[
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ];
+
+        struct ProxyEnvScope {
+            saved: Vec<(&'static str, Option<String>)>,
+        }
+
+        impl ProxyEnvScope {
+            fn set_unreachable_proxy(url: &str) -> Self {
+                let saved = PROXY_VARS
+                    .iter()
+                    .map(|&key| {
+                        let prev = env::var(key).ok();
+                        env::remove_var(key);
+                        (key, prev)
+                    })
+                    .collect();
+
+                env::set_var("HTTPS_PROXY", url);
+                env::set_var("https_proxy", url);
+                env::set_var("ALL_PROXY", url);
+                env::set_var("all_proxy", url);
+                env::set_var("NO_PROXY", "127.0.0.1,localhost");
+                env::set_var("no_proxy", "127.0.0.1,localhost");
+
+                Self { saved }
+            }
+        }
+
+        impl Drop for ProxyEnvScope {
+            fn drop(&mut self) {
+                for (key, value) in &self.saved {
+                    match value {
+                        Some(v) => env::set_var(key, v),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+
+        fn restore_env(key: &str, value: Option<String>) {
+            match value {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
+        }
+
+        let _guard = crate::test_support::lock_env();
+        let original_api_key = env::var("STEAM_API_KEY").ok();
+        let original_steam_id = env::var("STEAM_ID").ok();
+        env::set_var("STEAM_API_KEY", "env-test-key");
+        env::set_var("STEAM_ID", "76561197960265728");
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let proxy_url = format!("http://{}", listener.local_addr().expect("local addr"));
+        drop(listener);
+        let _proxy = ProxyEnvScope::set_unreachable_proxy(&proxy_url);
+
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = env::temp_dir().join(format!(
+            "steamfetch-fetch-web-stats-env-{}-{}.toml",
+            std::process::id(),
+            nanos
+        ));
+        std::fs::write(&path, "").unwrap();
+
+        let cli = Cli {
+            demo: false,
+            verbose: true,
+            config: Some(path.clone()),
+            config_path: false,
+            timeout: 1,
+            image: false,
+            image_protocol: ImageProtocol::Auto,
+        };
+
+        let err = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt")
+            .block_on(fetch_web_stats(&cli))
+            .expect_err("unreachable proxy should make env-backed fetch fail");
+
+        let _ = std::fs::remove_file(&path);
+        restore_env("STEAM_API_KEY", original_api_key);
+        restore_env("STEAM_ID", original_steam_id);
 
         assert!(err.downcast_ref::<steam::error::SteamApiError>().is_some());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -226,6 +226,19 @@ mod tests {
     }
 
     #[test]
+    fn test_demo_stats_profile_details_are_present() {
+        let stats = demo_stats();
+        let achievements = stats.achievement_stats.as_ref().expect("demo achievements");
+        let rarest = achievements.rarest.as_ref().expect("demo rarest");
+
+        assert_eq!(stats.account_created, Some(1234567890));
+        assert_eq!(stats.steam_level, Some(42));
+        assert_eq!(rarest.name, "Impossible Task");
+        assert_eq!(rarest.game, "Dark Souls III");
+        assert_eq!(stats.recently_played[0].playtime_minutes, 1200);
+    }
+
+    #[test]
     fn test_cli_parses_minimum_args() {
         let cli = Cli::try_parse_from(["steamfetch"]).expect("default args should parse");
         assert!(!cli.demo);

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,6 +333,16 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_rejects_invalid_timeout_values() {
+        [
+            ["steamfetch", "--timeout", "not-a-number"],
+            ["steamfetch", "--timeout", "-1"],
+        ]
+        .into_iter()
+        .for_each(|args| assert!(Cli::try_parse_from(args).is_err()));
+    }
+
+    #[test]
     fn test_cli_parses_image_with_protocol() {
         let cli = Cli::try_parse_from(["steamfetch", "--image", "--image-protocol", "kitty"])
             .expect("image flags should parse");

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,17 +321,9 @@ mod tests {
         // hit the web-stats path.
         use std::env;
         use std::path::PathBuf;
-        use std::sync::Mutex;
         use std::time::{SystemTime, UNIX_EPOCH};
 
-        // $HOME mutation is process-global; serialize within this test
-        // module. Cross-module races with src/steam/native.rs's HOME
-        // manipulation are still possible, but every alternative HOME those
-        // tests install either has no steamclient files or only "stub" bytes
-        // that `Library::new` cannot dlopen, so the `None` arm of
-        // `fetch_stats` is reached either way.
-        static HOME_LOCK: Mutex<()> = Mutex::new(());
-        let _guard = HOME_LOCK.lock().unwrap();
+        let _guard = crate::test_support::lock_env();
 
         let nanos = SystemTime::now()
             .duration_since(UNIX_EPOCH)

--- a/src/main.rs
+++ b/src/main.rs
@@ -670,8 +670,10 @@ steam_id = "76561197960265728"
         }
 
         let _guard = crate::test_support::lock_env();
-        let original_api_key = env::var("STEAM_API_KEY").ok();
+        let outer_api_key = env::var("STEAM_API_KEY").ok();
         let original_steam_id = env::var("STEAM_ID").ok();
+        env::set_var("STEAM_API_KEY", "outer-env-key");
+        let original_api_key = env::var("STEAM_API_KEY").ok();
         env::set_var("STEAM_API_KEY", "env-test-key");
         env::set_var("STEAM_ID", "76561197960265728");
 
@@ -711,6 +713,7 @@ steam_id = "76561197960265728"
         let _ = std::fs::remove_file(&path);
         restore_env("STEAM_API_KEY", original_api_key);
         restore_env("STEAM_ID", original_steam_id);
+        restore_env("STEAM_API_KEY", outer_api_key);
 
         assert!(err.downcast_ref::<steam::error::SteamApiError>().is_some());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,6 +239,37 @@ mod tests {
     }
 
     #[test]
+    fn test_demo_stats_fixture_values_are_stable() {
+        let stats = demo_stats();
+        let top_games = stats
+            .top_games
+            .iter()
+            .map(|game| (game.name.as_str(), game.playtime_minutes))
+            .collect::<Vec<_>>();
+        let recently_played = stats
+            .recently_played
+            .iter()
+            .map(|game| (game.name.as_str(), game.playtime_minutes))
+            .collect::<Vec<_>>();
+
+        assert_eq!(stats.game_count, 486);
+        assert_eq!(stats.unplayed_count, 123);
+        assert_eq!(stats.total_playtime_minutes, 170820);
+        assert_eq!(
+            top_games,
+            vec![
+                ("Borderlands 3", 28680),
+                ("Coin Push RPG", 22620),
+                ("DRG Survivor", 15120),
+            ],
+        );
+        assert_eq!(
+            recently_played,
+            vec![("Elden Ring", 1200), ("Hades II", 480)]
+        );
+    }
+
+    #[test]
     fn test_cli_parses_minimum_args() {
         let cli = Cli::try_parse_from(["steamfetch"]).expect("default args should parse");
         assert!(!cli.demo);

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,6 +263,31 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_parses_verbose_long_flag_with_other_options() {
+        let cli = Cli::try_parse_from([
+            "steamfetch",
+            "--verbose",
+            "--timeout",
+            "5",
+            "--image",
+            "--image-protocol",
+            "sixel",
+            "--config",
+            "/tmp/steamfetch.toml",
+        ])
+        .expect("long verbose and related options should parse");
+
+        assert!(cli.verbose);
+        assert_eq!(cli.timeout, 5);
+        assert!(cli.image);
+        assert!(matches!(cli.image_protocol, ImageProtocol::Sixel));
+        assert_eq!(
+            cli.config.as_deref(),
+            Some(std::path::Path::new("/tmp/steamfetch.toml"))
+        );
+    }
+
+    #[test]
     fn test_cli_parses_config_path_flag() {
         let cli = Cli::try_parse_from(["steamfetch", "--config-path"])
             .expect("--config-path should parse");

--- a/src/main.rs
+++ b/src/main.rs
@@ -467,48 +467,63 @@ mod tests {
         }
 
         let _guard = crate::test_support::lock_env();
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
-        let addr = listener.local_addr().expect("local addr");
-        drop(listener);
-        let _scope = EnvScope::set_unreachable_proxy(&format!("http://{}", addr));
+        let outer_all_proxy = env::var("ALL_PROXY").ok();
+        env::set_var("ALL_PROXY", "http://proxy-sentinel.invalid:9");
 
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0);
-        let path = env::temp_dir().join(format!(
-            "steamfetch-fetch-web-stats-valid-{}-{}.toml",
-            std::process::id(),
-            nanos
-        ));
-        std::fs::write(
-            &path,
-            r#"
+        let err = {
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+            let addr = listener.local_addr().expect("local addr");
+            drop(listener);
+            let _scope = EnvScope::set_unreachable_proxy(&format!("http://{}", addr));
+
+            let nanos = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0);
+            let path = env::temp_dir().join(format!(
+                "steamfetch-fetch-web-stats-valid-{}-{}.toml",
+                std::process::id(),
+                nanos
+            ));
+            std::fs::write(
+                &path,
+                r#"
 [api]
 steam_api_key = "test-key"
 steam_id = "76561197960265728"
 "#,
-        )
-        .unwrap();
+            )
+            .unwrap();
 
-        let cli = Cli {
-            demo: false,
-            verbose: false,
-            config: Some(path.clone()),
-            config_path: false,
-            timeout: 1,
-            image: false,
-            image_protocol: ImageProtocol::Auto,
+            let cli = Cli {
+                demo: false,
+                verbose: false,
+                config: Some(path.clone()),
+                config_path: false,
+                timeout: 1,
+                image: false,
+                image_protocol: ImageProtocol::Auto,
+            };
+
+            let err = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(fetch_web_stats(&cli))
+                .expect_err("unreachable proxy should make fetch_stats fail");
+
+            let _ = std::fs::remove_file(&path);
+            err
         };
 
-        let err = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("rt")
-            .block_on(fetch_web_stats(&cli))
-            .expect_err("unreachable proxy should make fetch_stats fail");
-
-        let _ = std::fs::remove_file(&path);
+        assert_eq!(
+            env::var("ALL_PROXY").unwrap(),
+            "http://proxy-sentinel.invalid:9"
+        );
+        match outer_all_proxy {
+            Some(v) => env::set_var("ALL_PROXY", v),
+            None => env::remove_var("ALL_PROXY"),
+        }
 
         assert!(err.downcast_ref::<steam::error::SteamApiError>().is_some());
     }

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1680,6 +1680,62 @@ mod tests {
             assert!((rarest.percent - 3.0).abs() < f64::EPSILON);
         }
 
+        #[test]
+        fn test_fetch_achievement_stats_fetches_cache_misses_from_api() {
+            let _guard = crate::test_support::lock_env();
+            let cache_root = super::unique_temp_root("achievement-cache-miss");
+            let previous_cache = std::env::var("XDG_CACHE_HOME").ok();
+            std::env::set_var("XDG_CACHE_HOME", &cache_root);
+
+            let files = [
+                (
+                    "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=555&l=english",
+                    r#"{"playerstats":{"achievements":[{"apiname":"FIRST","achieved":1,"name":"First Win"},{"apiname":"SECOND","achieved":1,"name":"Second Win"},{"apiname":"LOCKED","achieved":0,"name":"Locked"}]}}"#,
+                ),
+                (
+                    "ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid=555",
+                    r#"{"achievementpercentages":{"achievements":[{"name":"FIRST","percent":20.0},{"name":"SECOND","percent":4.5},{"name":"LOCKED","percent":1.0}]}}"#,
+                ),
+            ];
+            let Some(server) = super::spawn_tls_server(&files, files.len()) else {
+                super::restore_xdg_cache_home(previous_cache);
+                let _ = std::fs::remove_dir_all(&cache_root);
+                return;
+            };
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(3))
+                    .resolve("api.steampowered.com", server.addr)
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(3),
+            };
+            let games = super::super::super::models::OwnedGamesData {
+                game_count: 1,
+                games: vec![super::make_game(555, Some("Fetched Game"), 9876)],
+            };
+
+            let stats = run_async(client.fetch_achievement_stats(&games))
+                .expect("cache miss should be fetched from the API");
+
+            assert_eq!(stats.total_achieved, 2);
+            assert_eq!(stats.total_possible, 3);
+            assert_eq!(stats.perfect_games, 0);
+            let rarest = stats.rarest.expect("fetched result should include rarest");
+            assert_eq!(rarest.name, "Second Win");
+            assert_eq!(rarest.game, "Fetched Game");
+            assert!((rarest.percent - 4.5).abs() < f64::EPSILON);
+
+            drop(server);
+            super::restore_xdg_cache_home(previous_cache);
+            let _ = std::fs::remove_dir_all(&cache_root);
+        }
+
         #[cfg(target_os = "linux")]
         mod cache_hit_tests {
             use super::super::super::*;

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1004,6 +1004,39 @@ mod tests {
         }
 
         #[test]
+        fn test_request_with_retry_defaults_api_error_body_when_read_fails() {
+            // 400 enters classify_http_error's catch-all arm. The server
+            // advertises a body and closes early, so response.text() fails and
+            // unwrap_or_default supplies the empty message.
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+            let addr = listener.local_addr().expect("addr");
+            let url = format!("http://{}/", addr);
+
+            let server = std::thread::spawn(move || {
+                if let Ok((mut stream, _)) = listener.accept() {
+                    let mut buf = [0u8; 1024];
+                    let _ = stream.read(&mut buf);
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 400 Bad Request\r\nContent-Length: 100\r\nConnection: close\r\n\r\n",
+                    );
+                    let _ = stream.flush();
+                }
+            });
+
+            let client = SteamClient::new("k".into(), "id".into()).with_timeout(2);
+            let err = run_async(client.request_with_retry(&url, "truncated-400"))
+                .expect_err("truncated 400 body should still classify as ApiError");
+            match err.downcast_ref::<SteamApiError>().unwrap() {
+                SteamApiError::ApiError { status, message } => {
+                    assert_eq!(*status, 400);
+                    assert!(message.is_empty());
+                }
+                other => panic!("unexpected error: {:?}", other),
+            }
+            let _ = server.join();
+        }
+
+        #[test]
         fn test_request_with_retry_exhausts_retries_on_429() {
             // 429 → RateLimited (retryable). All 3 attempts fail, so the
             // loop completes and the last error is returned.

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1754,6 +1754,78 @@ mod tests {
         }
 
         #[test]
+        fn test_fetch_game_achievements_returns_none_when_player_json_is_malformed() {
+            let _guard = crate::test_support::lock_env();
+            let files = [
+                (
+                    "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=987&l=english",
+                    r#"{"playerstats":{"achievements":["#,
+                ),
+                (
+                    "ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid=987",
+                    r#"{"achievementpercentages":{"achievements":[{"name":"ACH_ONE","percent":7.5}]}}"#,
+                ),
+            ];
+            let Some(server) = super::spawn_tls_server(&files, files.len()) else {
+                return;
+            };
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(3))
+                    .resolve("api.steampowered.com", server.addr)
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(3),
+            };
+
+            let result = run_async(client.fetch_game_achievements(987, "Game 987".to_string()));
+            assert!(result.is_none());
+        }
+
+        #[test]
+        fn test_fetch_game_achievements_ignores_malformed_global_json() {
+            let _guard = crate::test_support::lock_env();
+            let files = [
+                (
+                    "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=988&l=english",
+                    r#"{"playerstats":{"achievements":[{"apiname":"ACH_ONE","achieved":1,"name":"One"},{"apiname":"ACH_TWO","achieved":0,"name":"Two"}]}}"#,
+                ),
+                (
+                    "ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid=988",
+                    r#"{"achievementpercentages":{"achievements":["#,
+                ),
+            ];
+            let server = match super::spawn_tls_server(&files, files.len()) {
+                Some(server) => server,
+                None => return,
+            };
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(3))
+                    .resolve("api.steampowered.com", server.addr)
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(3),
+            };
+
+            let result = run_async(client.fetch_game_achievements(988, "Game 988".to_string()))
+                .expect("player achievements should still provide counts");
+            assert_eq!(result.achieved, 1);
+            assert_eq!(result.total, 2);
+            assert!(result.rarest.is_none());
+        }
+
+        #[test]
         fn test_fetch_game_achievements_returns_zero_counts_for_empty_list() {
             let _guard = crate::test_support::lock_env();
             let files = [

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -876,6 +876,33 @@ mod tests {
     }
 
     #[test]
+    fn test_fetch_steam_level_returns_none_for_null_level() {
+        let _guard = crate::test_support::lock_env();
+        let server = spawn_tls_one_shot_server(
+            "IPlayerService/GetSteamLevel/v1/?key=k&steamid=id",
+            r#"{"response":{"player_level":null}}"#,
+        )
+        .expect("TLS test server should start");
+        let client = SteamClient {
+            client: Client::builder()
+                .danger_accept_invalid_certs(true)
+                .no_proxy()
+                .timeout(Duration::from_secs(3))
+                .resolve("api.steampowered.com", server.addr)
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: false,
+            timeout: Duration::from_secs(3),
+        };
+
+        let level = run_async(client.fetch_steam_level()).expect("steam level should parse");
+
+        assert_eq!(level, None);
+    }
+
+    #[test]
     fn test_fetch_stats_builds_success_response_from_api_data() {
         let _guard = crate::test_support::lock_env();
         let cache_root = unique_temp_root("fetch-stats-success-cache");

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1690,7 +1690,7 @@ mod tests {
             let files = [
                 (
                     "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=555&l=english",
-                    r#"{"playerstats":{"achievements":[{"apiname":"FIRST","achieved":1,"name":"First Win"},{"apiname":"SECOND","achieved":1,"name":"Second Win"},{"apiname":"LOCKED","achieved":0,"name":"Locked"}]}}"#,
+                    r#"{"playerstats":{"achievements":[{"apiname":"FIRST","achieved":1,"name":"First Win"},{"apiname":"SECOND","achieved":1,"name":"Second Win"},{"apiname":"LOCKED","achieved":1,"name":"Locked"}]}}"#,
                 ),
                 (
                     "ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid=555",
@@ -1723,13 +1723,13 @@ mod tests {
             let stats = run_async(client.fetch_achievement_stats(&games))
                 .expect("cache miss should be fetched from the API");
 
-            assert_eq!(stats.total_achieved, 2);
+            assert_eq!(stats.total_achieved, 3);
             assert_eq!(stats.total_possible, 3);
-            assert_eq!(stats.perfect_games, 0);
+            assert_eq!(stats.perfect_games, 1);
             let rarest = stats.rarest.expect("fetched result should include rarest");
-            assert_eq!(rarest.name, "Second Win");
+            assert_eq!(rarest.name, "Locked");
             assert_eq!(rarest.game, "Fetched Game");
-            assert!((rarest.percent - 4.5).abs() < f64::EPSILON);
+            assert!((rarest.percent - 1.0).abs() < f64::EPSILON);
 
             drop(server);
             super::restore_xdg_cache_home(previous_cache);

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -888,6 +888,85 @@ mod tests {
     }
 
     #[test]
+    fn test_fetch_stats_for_appids_builds_success_response_from_filtered_api_data() {
+        let _guard = crate::test_support::lock_env();
+        let cache_root = unique_temp_root("fetch-stats-for-appids-success-cache");
+        let previous_cache = std::env::var("XDG_CACHE_HOME").ok();
+        std::env::set_var("XDG_CACHE_HOME", &cache_root);
+
+        let mut cache = crate::cache::AchievementCache::default();
+        cache.set(100, 1000, 2, 2, Some(("Native Rare", 4.0)));
+        cache.set(200, 2000, 1, 3, None);
+        cache.set(300, 0, 0, 1, Some(("Missing Game Rare", 2.0)));
+        cache.save();
+
+        let files = [
+            (
+                "ISteamUser/GetPlayerSummaries/v2/?key=k&steamids=id",
+                r#"{"response":{"players":[{"personaname":"Web User","timecreated":2222,"avatarfull":"https://example.test/native.png"}]}}"#,
+            ),
+            (
+                "IPlayerService/GetOwnedGames/v1/?key=k&steamid=id&include_appinfo=1&include_played_free_games=1&appids_filter%5B0%5D=100&appids_filter%5B1%5D=200&appids_filter%5B2%5D=300",
+                r#"{"response":{"game_count":2,"games":[{"appid":100,"name":"Native Game One","playtime_forever":90,"rtime_last_played":1000},{"appid":200,"name":"Native Game Two","playtime_forever":0,"rtime_last_played":2000}]}}"#,
+            ),
+            (
+                "IPlayerService/GetSteamLevel/v1/?key=k&steamid=id",
+                r#"{"response":{"player_level":7}}"#,
+            ),
+            (
+                "IPlayerService/GetRecentlyPlayedGames/v1/?key=k&steamid=id&count=5",
+                r#"{"response":{"games":[{"appid":200,"playtime_forever":0,"playtime_2weeks":15}]}}"#,
+            ),
+        ];
+        let Some(server) = spawn_tls_server(&files, files.len()) else {
+            restore_xdg_cache_home(previous_cache);
+            let _ = std::fs::remove_dir_all(&cache_root);
+            return;
+        };
+        let client = SteamClient {
+            client: Client::builder()
+                .danger_accept_invalid_certs(true)
+                .no_proxy()
+                .timeout(Duration::from_secs(3))
+                .resolve("api.steampowered.com", server.addr)
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: true,
+            timeout: Duration::from_secs(3),
+        };
+
+        let stats = run_async(client.fetch_stats_for_appids(&[100, 200, 300], "Native User"))
+            .expect("filtered stats response should parse");
+
+        assert_eq!(stats.username, "Native User");
+        assert_eq!(stats.game_count, 3);
+        assert_eq!(stats.unplayed_count, 1);
+        assert_eq!(stats.total_playtime_minutes, 90);
+        assert_eq!(stats.account_created, Some(2222));
+        assert_eq!(stats.steam_level, Some(7));
+        assert_eq!(
+            stats.avatar_url.as_deref(),
+            Some("https://example.test/native.png")
+        );
+        assert_eq!(stats.top_games[0].name, "Native Game One");
+        assert_eq!(stats.recently_played[0].name, "App 200");
+
+        let achievement_stats = stats.achievement_stats.expect("cached achievements");
+        assert_eq!(achievement_stats.total_achieved, 3);
+        assert_eq!(achievement_stats.total_possible, 6);
+        assert_eq!(achievement_stats.perfect_games, 1);
+        let rarest = achievement_stats.rarest.expect("rarest achievement");
+        assert_eq!(rarest.name, "Missing Game Rare");
+        assert_eq!(rarest.game, "App 300");
+
+        drop(server);
+        restore_xdg_cache_home(previous_cache);
+        let _ = std::fs::remove_dir_all(&cache_root);
+    }
+
+    #[test]
     fn test_detect_private_profile_no_games_key() {
         let body = r#"{"response":{"game_count":0}}"#;
         let result = detect_private_profile(body);

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1681,6 +1681,38 @@ mod tests {
         }
 
         #[test]
+        fn test_fetch_game_achievements_keeps_counts_when_global_percentages_fail() {
+            let _guard = crate::test_support::lock_env();
+            let files = [(
+                "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=321&l=english",
+                r#"{"playerstats":{"achievements":[{"apiname":"ACH_ONE","achieved":1,"name":"Named One"},{"apiname":"ACH_TWO","achieved":0,"name":"Locked"}]}}"#,
+            )];
+            let Some(server) = super::spawn_tls_server(&files, 2) else {
+                return;
+            };
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(3))
+                    .resolve("api.steampowered.com", server.addr)
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(3),
+            };
+
+            let result = run_async(client.fetch_game_achievements(321, "Game 321".to_string()))
+                .expect("player achievement response should still produce a result");
+
+            assert_eq!(result.achieved, 1);
+            assert_eq!(result.total, 2);
+            assert!(result.rarest.is_none());
+        }
+
+        #[test]
         fn test_fetch_achievement_stats_fetches_cache_misses_from_api() {
             let _guard = crate::test_support::lock_env();
             let cache_root = super::unique_temp_root("achievement-cache-miss");

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -640,6 +640,103 @@ mod tests {
         addr
     }
 
+    struct TlsOneShotServer {
+        addr: std::net::SocketAddr,
+        child: std::process::Child,
+        stdin: Option<std::process::ChildStdin>,
+        root: std::path::PathBuf,
+    }
+
+    impl Drop for TlsOneShotServer {
+        fn drop(&mut self) {
+            drop(self.stdin.take());
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+            let _ = std::fs::remove_dir_all(&self.root);
+        }
+    }
+
+    fn spawn_tls_one_shot_server(body: &'static str) -> Option<TlsOneShotServer> {
+        use std::io::Write;
+        use std::process::{Command, Stdio};
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let root = std::env::temp_dir().join(format!(
+            "steamfetch-tls-test-{}-{}",
+            std::process::id(),
+            nanos
+        ));
+        std::fs::create_dir_all(&root).ok()?;
+        let cert = root.join("cert.pem");
+        let key = root.join("key.pem");
+
+        let output = Command::new("openssl")
+            .args([
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-nodes",
+                "-keyout",
+                key.to_str()?,
+                "-out",
+                cert.to_str()?,
+                "-subj",
+                "/CN=api.steampowered.com",
+                "-days",
+                "1",
+            ])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            let _ = std::fs::remove_dir_all(&root);
+            return None;
+        }
+
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+        drop(listener);
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        let mut child = Command::new("openssl")
+            .args([
+                "s_server",
+                "-quiet",
+                "-accept",
+                &addr.port().to_string(),
+                "-cert",
+                cert.to_str()?,
+                "-key",
+                key.to_str()?,
+                "-naccept",
+                "1",
+            ])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .ok()?;
+        let mut stdin = child.stdin.take()?;
+        stdin.write_all(response.as_bytes()).ok()?;
+        stdin.flush().ok()?;
+        std::thread::sleep(Duration::from_millis(100));
+
+        Some(TlsOneShotServer {
+            addr,
+            child,
+            stdin: Some(stdin),
+            root,
+        })
+    }
+
     #[test]
     fn test_detect_api_error_empty_players() {
         let body = r#"{"response":{"players":[]}}"#;
@@ -652,6 +749,37 @@ mod tests {
         let body = r#"{"response":{"players":[{"personaname":"test"}]}}"#;
         let result = detect_api_error(body, false);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_fetch_player_parses_success_response() {
+        let _guard = crate::test_support::lock_env();
+        let body = r#"{"response":{"players":[{"personaname":"TLS User","timecreated":1234567890,"avatarfull":"https://example.test/avatar.png"}]}}"#;
+        let Some(server) = spawn_tls_one_shot_server(body) else {
+            return;
+        };
+        let client = SteamClient {
+            client: Client::builder()
+                .danger_accept_invalid_certs(true)
+                .no_proxy()
+                .timeout(Duration::from_secs(3))
+                .resolve("api.steampowered.com", server.addr)
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: true,
+            timeout: Duration::from_secs(3),
+        };
+
+        let player = run_async(client.fetch_player()).expect("player response should parse");
+
+        assert_eq!(player.personaname, "TLS User");
+        assert_eq!(player.timecreated, Some(1234567890));
+        assert_eq!(
+            player.avatarfull.as_deref(),
+            Some("https://example.test/avatar.png")
+        );
     }
 
     #[test]

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1713,6 +1713,46 @@ mod tests {
         }
 
         #[test]
+        fn test_fetch_game_achievements_returns_zero_counts_for_empty_list() {
+            let _guard = crate::test_support::lock_env();
+            let files = [
+                (
+                    "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=654&l=english",
+                    r#"{"playerstats":{"achievements":[]}}"#,
+                ),
+                (
+                    "ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid=654",
+                    r#"{"achievementpercentages":{"achievements":[{"name":"UNUSED","percent":1.0}]}}"#,
+                ),
+            ];
+            let Some(server) = super::spawn_tls_server(&files, files.len()) else {
+                return;
+            };
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(3))
+                    .resolve("api.steampowered.com", server.addr)
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(3),
+            };
+
+            let result = run_async(client.fetch_game_achievements(654, "Game 654".to_string()))
+                .expect("empty achievement list should still produce counts");
+            let counts = (result.achieved, result.total);
+            let expected_counts = (0, 0);
+            let has_rarest = result.rarest.is_some();
+
+            assert_eq!(counts, expected_counts);
+            assert!(!has_rarest);
+        }
+
+        #[test]
         fn test_fetch_achievement_stats_fetches_cache_misses_from_api() {
             let _guard = crate::test_support::lock_env();
             let cache_root = super::unique_temp_root("achievement-cache-miss");

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -747,6 +747,37 @@ mod tests {
         spawn_tls_server(&[(request_path, body)], 1)
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn test_spawn_tls_server_returns_none_when_openssl_fails() {
+        use std::env;
+        use std::os::unix::fs::PermissionsExt;
+
+        let _guard = crate::test_support::lock_env();
+        let root = unique_temp_root("fake-openssl");
+        std::fs::create_dir_all(&root).expect("fake openssl dir should be created");
+        let openssl = root.join("openssl");
+        std::fs::write(&openssl, "#!/bin/sh\nexit 1\n").expect("fake openssl should be written");
+        let mut perms = std::fs::metadata(&openssl)
+            .expect("fake openssl metadata should exist")
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&openssl, perms).expect("fake openssl should be executable");
+
+        let previous_path = env::var("PATH").ok();
+        env::set_var("PATH", &root);
+
+        let server = spawn_tls_server(&[], 1);
+
+        match previous_path {
+            Some(path) => env::set_var("PATH", path),
+            None => env::remove_var("PATH"),
+        }
+        let _ = std::fs::remove_dir_all(&root);
+
+        assert!(server.is_none());
+    }
+
     fn unique_temp_root(label: &str) -> std::path::PathBuf {
         use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -846,6 +846,25 @@ mod tests {
     }
 
     #[test]
+    fn test_fetch_stats_for_appids_propagates_player_fetch_failure() {
+        let client = SteamClient {
+            client: Client::builder()
+                .timeout(Duration::from_secs(1))
+                .resolve("api.steampowered.com", unbound_localhost_addr())
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: false,
+            timeout: Duration::from_secs(1),
+        };
+
+        let err = run_async(client.fetch_stats_for_appids(&[1, 2], "native-user"))
+            .expect_err("player fetch should fail before appid filtering");
+        assert!(err.downcast_ref::<SteamApiError>().is_some());
+    }
+
+    #[test]
     fn test_print_status_does_not_panic() {
         // Writes a CR + clear-line escape + message to stderr; the
         // assertion is simply that it completes without panicking.

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -625,6 +625,21 @@ struct GameAchievementResult {
 mod tests {
     use super::*;
 
+    fn run_async<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt")
+            .block_on(f)
+    }
+
+    fn unbound_localhost_addr() -> std::net::SocketAddr {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+        drop(listener);
+        addr
+    }
+
     #[test]
     fn test_detect_api_error_empty_players() {
         let body = r#"{"response":{"players":[]}}"#;
@@ -813,6 +828,24 @@ mod tests {
     }
 
     #[test]
+    fn test_fetch_stats_propagates_player_fetch_failure() {
+        let client = SteamClient {
+            client: Client::builder()
+                .timeout(Duration::from_secs(1))
+                .resolve("api.steampowered.com", unbound_localhost_addr())
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: false,
+            timeout: Duration::from_secs(1),
+        };
+
+        let err = run_async(client.fetch_stats()).expect_err("player fetch should fail first");
+        assert!(err.downcast_ref::<SteamApiError>().is_some());
+    }
+
+    #[test]
     fn test_print_status_does_not_panic() {
         // Writes a CR + clear-line escape + message to stderr; the
         // assertion is simply that it completes without panicking.
@@ -893,22 +926,7 @@ mod tests {
 
     mod fetch_optional_details_tests {
         use super::super::*;
-        use std::net::{SocketAddr, TcpListener};
-
-        fn run_async<F: std::future::Future>(f: F) -> F::Output {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .expect("rt")
-                .block_on(f)
-        }
-
-        fn unbound_localhost_addr() -> SocketAddr {
-            let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
-            let addr = listener.local_addr().expect("local_addr");
-            drop(listener);
-            addr
-        }
+        use super::{run_async, unbound_localhost_addr};
 
         #[test]
         fn test_fetch_optional_details_returns_empty_values_when_requests_fail() {

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1768,6 +1768,38 @@ mod tests {
             let _ = std::fs::remove_dir_all(&cache_root);
         }
 
+        #[test]
+        fn test_fetch_achievement_stats_skips_game_when_player_achievements_fail() {
+            let _guard = crate::test_support::lock_env();
+            let cache_root = super::unique_temp_root("achievement-player-fetch-fail");
+            let previous_cache = std::env::var("XDG_CACHE_HOME").ok();
+            std::env::set_var("XDG_CACHE_HOME", &cache_root);
+
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(1))
+                    .resolve("api.steampowered.com", super::unbound_localhost_addr())
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(1),
+            };
+            let games = super::super::super::models::OwnedGamesData {
+                game_count: 1,
+                games: vec![super::make_game(777, Some("Unavailable Game"), 0)],
+            };
+
+            let stats = run_async(client.fetch_achievement_stats(&games));
+
+            super::restore_xdg_cache_home(previous_cache);
+            let _ = std::fs::remove_dir_all(&cache_root);
+
+            assert!(stats.is_none());
+        }
+
         #[cfg(target_os = "linux")]
         mod cache_hit_tests {
             use super::super::super::*;

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1639,6 +1639,47 @@ mod tests {
             assert!(result.is_none());
         }
 
+        #[test]
+        fn test_fetch_game_achievements_builds_counts_and_rarest_from_api_data() {
+            let _guard = crate::test_support::lock_env();
+            let files = [
+                (
+                    "ISteamUserStats/GetPlayerAchievements/v1/?key=k&steamid=id&appid=123&l=english",
+                    r#"{"playerstats":{"achievements":[{"apiname":"ACH_ONE","achieved":1,"name":"Named One"},{"apiname":"ACH_TWO","achieved":0,"name":"Locked"},{"apiname":"ach_three","achieved":1,"name":null}]}}"#,
+                ),
+                (
+                    "ISteamUserStats/GetGlobalAchievementPercentagesForApp/v2/?gameid=123",
+                    r#"{"achievementpercentages":{"achievements":[{"name":"ACH_ONE","percent":12.5},{"name":"ACH_THREE","percent":3.0}]}}"#,
+                ),
+            ];
+            let Some(server) = super::spawn_tls_server(&files, files.len()) else {
+                return;
+            };
+            let client = SteamClient {
+                client: reqwest::Client::builder()
+                    .danger_accept_invalid_certs(true)
+                    .no_proxy()
+                    .timeout(std::time::Duration::from_secs(3))
+                    .resolve("api.steampowered.com", server.addr)
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: false,
+                timeout: std::time::Duration::from_secs(3),
+            };
+
+            let result = run_async(client.fetch_game_achievements(123, "Game 123".to_string()))
+                .expect("achievement responses should produce a result");
+
+            assert_eq!(result.achieved, 2);
+            assert_eq!(result.total, 3);
+            let rarest = result.rarest.expect("achieved item has percentage data");
+            assert_eq!(rarest.name, "ach_three");
+            assert_eq!(rarest.game, "Game 123");
+            assert!((rarest.percent - 3.0).abs() < f64::EPSILON);
+        }
+
         #[cfg(target_os = "linux")]
         mod cache_hit_tests {
             use super::super::super::*;

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -2015,6 +2015,54 @@ mod tests {
                 }
             }
 
+            #[test]
+            fn test_envscope_drop_restores_previous_xdg_cache_home() {
+                let _guard = lock_env();
+                let outer_prev = env::var("XDG_CACHE_HOME").ok();
+                let sentinel = unique_cache_root("envscope-sentinel");
+                env::set_var("XDG_CACHE_HOME", &sentinel);
+
+                {
+                    let scoped = unique_cache_root("envscope-scoped");
+                    let _scope = EnvScope::set(&scoped);
+                    assert_eq!(
+                        env::var("XDG_CACHE_HOME").unwrap(),
+                        scoped.to_string_lossy()
+                    );
+                }
+
+                assert_eq!(
+                    env::var("XDG_CACHE_HOME").unwrap(),
+                    sentinel.to_string_lossy()
+                );
+
+                super::super::restore_xdg_cache_home(outer_prev);
+            }
+
+            #[test]
+            fn test_envscope_drop_preserves_outer_xdg_cache_home() {
+                let _guard = lock_env();
+                let original = env::var("XDG_CACHE_HOME").ok();
+                let outer = unique_cache_root("envscope-outer");
+                env::set_var("XDG_CACHE_HOME", &outer);
+
+                {
+                    let scoped = unique_cache_root("envscope-inner");
+                    let _scope = EnvScope::set(&scoped);
+                    assert_eq!(
+                        env::var("XDG_CACHE_HOME").unwrap(),
+                        scoped.to_string_lossy()
+                    );
+                }
+
+                assert_eq!(env::var("XDG_CACHE_HOME").unwrap(), outer.to_string_lossy());
+
+                let outer_value = outer.to_string_lossy().into_owned();
+                super::super::restore_xdg_cache_home(Some(outer_value.clone()));
+                assert_eq!(env::var("XDG_CACHE_HOME").unwrap(), outer_value);
+                super::super::restore_xdg_cache_home(original);
+            }
+
             fn unique_cache_root(label: &str) -> std::path::PathBuf {
                 let nanos = SystemTime::now()
                     .duration_since(UNIX_EPOCH)

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -1420,6 +1420,19 @@ mod tests {
         }
 
         #[test]
+        fn test_request_with_retry_preserves_empty_api_error_body() {
+            let (url, server) = spawn_n_shot_server(1, 418, "I'm a Teapot", b"");
+            let client = SteamClient::new("k".into(), "id".into());
+            let err = run_async(client.request_with_retry(&url, "empty-body"))
+                .expect_err("non-retryable 418 should produce an API error");
+            assert!(matches!(
+                err.downcast_ref::<SteamApiError>().unwrap(),
+                SteamApiError::ApiError { status: 418, message } if message.is_empty()
+            ));
+            let _ = server.join();
+        }
+
+        #[test]
         fn test_request_with_retry_defaults_api_error_body_when_read_fails() {
             // 400 enters classify_http_error's catch-all arm. The server
             // advertises a body and closes early, so response.text() fails and

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -643,21 +643,21 @@ mod tests {
     struct TlsOneShotServer {
         addr: std::net::SocketAddr,
         child: std::process::Child,
-        stdin: Option<std::process::ChildStdin>,
         root: std::path::PathBuf,
     }
 
     impl Drop for TlsOneShotServer {
         fn drop(&mut self) {
-            drop(self.stdin.take());
             let _ = self.child.kill();
             let _ = self.child.wait();
             let _ = std::fs::remove_dir_all(&self.root);
         }
     }
 
-    fn spawn_tls_one_shot_server(body: &'static str) -> Option<TlsOneShotServer> {
-        use std::io::Write;
+    fn spawn_tls_server(
+        files: &[(&'static str, &'static str)],
+        accepted_connections: usize,
+    ) -> Option<TlsOneShotServer> {
         use std::process::{Command, Stdio};
         use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -701,15 +701,25 @@ mod tests {
         let addr = listener.local_addr().expect("local_addr");
         drop(listener);
 
-        let response = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
-            body.len(),
-            body
-        );
-        let mut child = Command::new("openssl")
+        for (request_path, body) in files {
+            let response_path = root.join(request_path);
+            std::fs::create_dir_all(response_path.parent()?).ok()?;
+            std::fs::write(
+                &response_path,
+                format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\r\n{}",
+                    body
+                ),
+            )
+            .ok()?;
+        }
+
+        let accepted_connections = accepted_connections.to_string();
+        let child = Command::new("openssl")
             .args([
                 "s_server",
                 "-quiet",
+                "-HTTP",
                 "-accept",
                 &addr.port().to_string(),
                 "-cert",
@@ -717,24 +727,46 @@ mod tests {
                 "-key",
                 key.to_str()?,
                 "-naccept",
-                "1",
+                &accepted_connections,
             ])
-            .stdin(Stdio::piped())
+            .current_dir(&root)
+            .stdin(Stdio::null())
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .spawn()
             .ok()?;
-        let mut stdin = child.stdin.take()?;
-        stdin.write_all(response.as_bytes()).ok()?;
-        stdin.flush().ok()?;
-        std::thread::sleep(Duration::from_millis(100));
+        std::thread::sleep(Duration::from_secs(1));
 
-        Some(TlsOneShotServer {
-            addr,
-            child,
-            stdin: Some(stdin),
-            root,
-        })
+        Some(TlsOneShotServer { addr, child, root })
+    }
+
+    fn spawn_tls_one_shot_server(
+        request_path: &'static str,
+        body: &'static str,
+    ) -> Option<TlsOneShotServer> {
+        spawn_tls_server(&[(request_path, body)], 1)
+    }
+
+    fn unique_temp_root(label: &str) -> std::path::PathBuf {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        std::env::temp_dir().join(format!(
+            "steamfetch-{}-{}-{}",
+            label,
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    fn restore_xdg_cache_home(previous: Option<String>) {
+        match previous {
+            Some(value) => std::env::set_var("XDG_CACHE_HOME", value),
+            None => std::env::remove_var("XDG_CACHE_HOME"),
+        }
     }
 
     #[test]
@@ -755,7 +787,9 @@ mod tests {
     fn test_fetch_player_parses_success_response() {
         let _guard = crate::test_support::lock_env();
         let body = r#"{"response":{"players":[{"personaname":"TLS User","timecreated":1234567890,"avatarfull":"https://example.test/avatar.png"}]}}"#;
-        let Some(server) = spawn_tls_one_shot_server(body) else {
+        let Some(server) =
+            spawn_tls_one_shot_server("ISteamUser/GetPlayerSummaries/v2/?key=k&steamids=id", body)
+        else {
             return;
         };
         let client = SteamClient {
@@ -780,6 +814,77 @@ mod tests {
             player.avatarfull.as_deref(),
             Some("https://example.test/avatar.png")
         );
+    }
+
+    #[test]
+    fn test_fetch_stats_builds_success_response_from_api_data() {
+        let _guard = crate::test_support::lock_env();
+        let cache_root = unique_temp_root("fetch-stats-success-cache");
+        let previous_cache = std::env::var("XDG_CACHE_HOME").ok();
+        std::env::set_var("XDG_CACHE_HOME", &cache_root);
+
+        let mut cache = crate::cache::AchievementCache::default();
+        cache.set(100, 1000, 1, 2, Some(("Rare One", 3.5)));
+        cache.set(200, 2000, 0, 2, None);
+        cache.save();
+
+        let files = [
+            (
+                "ISteamUser/GetPlayerSummaries/v2/?key=k&steamids=id",
+                r#"{"response":{"players":[{"personaname":"TLS User","timecreated":1234567890,"avatarfull":"https://example.test/avatar.png"}]}}"#,
+            ),
+            (
+                "IPlayerService/GetOwnedGames/v1/?key=k&steamid=id&include_appinfo=1&include_played_free_games=1",
+                r#"{"response":{"game_count":2,"games":[{"appid":100,"name":"Game One","playtime_forever":120,"rtime_last_played":1000},{"appid":200,"name":"Game Two","playtime_forever":0,"rtime_last_played":2000}]}}"#,
+            ),
+            (
+                "IPlayerService/GetSteamLevel/v1/?key=k&steamid=id",
+                r#"{"response":{"player_level":42}}"#,
+            ),
+            (
+                "IPlayerService/GetRecentlyPlayedGames/v1/?key=k&steamid=id&count=5",
+                r#"{"response":{"games":[{"appid":100,"name":"Game One","playtime_forever":120,"playtime_2weeks":30}]}}"#,
+            ),
+        ];
+        let Some(server) = spawn_tls_server(&files, files.len()) else {
+            restore_xdg_cache_home(previous_cache);
+            let _ = std::fs::remove_dir_all(&cache_root);
+            return;
+        };
+        let client = SteamClient {
+            client: Client::builder()
+                .danger_accept_invalid_certs(true)
+                .no_proxy()
+                .timeout(Duration::from_secs(3))
+                .resolve("api.steampowered.com", server.addr)
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: true,
+            timeout: Duration::from_secs(3),
+        };
+
+        let stats = run_async(client.fetch_stats()).expect("stats response should parse");
+
+        assert_eq!(stats.username, "TLS User");
+        assert_eq!(stats.game_count, 2);
+        assert_eq!(stats.unplayed_count, 1);
+        assert_eq!(stats.total_playtime_minutes, 120);
+        assert_eq!(stats.steam_level, Some(42));
+        assert_eq!(stats.recently_played[0].name, "Game One");
+        assert_eq!(stats.top_games[0].name, "Game One");
+        let achievement_stats = stats.achievement_stats.expect("cached achievements");
+        assert_eq!(achievement_stats.total_achieved, 1);
+        assert_eq!(achievement_stats.total_possible, 4);
+        assert_eq!(
+            achievement_stats.rarest.expect("rarest achievement").name,
+            "Rare One"
+        );
+
+        drop(server);
+        restore_xdg_cache_home(previous_cache);
+        let _ = std::fs::remove_dir_all(&cache_root);
     }
 
     #[test]
@@ -1460,18 +1565,10 @@ mod tests {
             use super::super::super::*;
             use crate::cache::AchievementCache;
             use crate::steam::models;
+            use crate::test_support::lock_env;
             use std::env;
             use std::path::Path;
-            use std::sync::Mutex;
             use std::time::{SystemTime, UNIX_EPOCH};
-
-            // XDG_CACHE_HOME is process-global; serialize mutations within this
-            // submodule. Other test files (cache.rs, image_display.rs,
-            // display.rs) hold their own ENV_LOCKs — cross-module races are
-            // possible but the test here only asserts on data that came from
-            // *this* test's pre-populated cache, so a stale read would
-            // surface as an assertion failure rather than silent flakiness.
-            static ENV_LOCK: Mutex<()> = Mutex::new(());
 
             struct EnvScope {
                 prev: Option<String>,
@@ -1539,7 +1636,7 @@ mod tests {
             where
                 F: Fn(&std::path::Path) -> bool,
             {
-                let _guard = ENV_LOCK.lock().unwrap();
+                let _guard = lock_env();
                 for attempt in 0..5 {
                     let root = unique_cache_root(&format!("{}-{}", label, attempt));
                     let scope = EnvScope::set(&root);

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -891,6 +891,45 @@ mod tests {
         });
     }
 
+    mod fetch_optional_details_tests {
+        use super::super::*;
+        use std::net::{SocketAddr, TcpListener};
+
+        fn run_async<F: std::future::Future>(f: F) -> F::Output {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("rt")
+                .block_on(f)
+        }
+
+        fn unbound_localhost_addr() -> SocketAddr {
+            let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+            let addr = listener.local_addr().expect("local_addr");
+            drop(listener);
+            addr
+        }
+
+        #[test]
+        fn test_fetch_optional_details_returns_empty_values_when_requests_fail() {
+            let client = SteamClient {
+                client: Client::builder()
+                    .timeout(Duration::from_secs(1))
+                    .resolve("api.steampowered.com", unbound_localhost_addr())
+                    .build()
+                    .expect("client should build"),
+                api_key: "k".into(),
+                steam_id: "id".into(),
+                verbose: true,
+                timeout: Duration::from_secs(1),
+            };
+            let (level, recently_played) = run_async(client.fetch_optional_details());
+
+            assert!(level.is_none());
+            assert!(recently_played.is_empty());
+        }
+    }
+
     mod request_with_retry_tests {
         use super::super::*;
         use std::io::{Read, Write};

--- a/src/steam/client.rs
+++ b/src/steam/client.rs
@@ -817,6 +817,34 @@ mod tests {
     }
 
     #[test]
+    fn test_fetch_recently_played_parse_error_has_context() {
+        let _guard = crate::test_support::lock_env();
+        let server = spawn_tls_one_shot_server(
+            "IPlayerService/GetRecentlyPlayedGames/v1/?key=k&steamid=id&count=5",
+            "{not-json",
+        )
+        .expect("TLS test server should start");
+        let client = SteamClient {
+            client: Client::builder()
+                .danger_accept_invalid_certs(true)
+                .no_proxy()
+                .timeout(Duration::from_secs(3))
+                .resolve("api.steampowered.com", server.addr)
+                .build()
+                .expect("client should build"),
+            api_key: "k".into(),
+            steam_id: "id".into(),
+            verbose: true,
+            timeout: Duration::from_secs(3),
+        };
+
+        let err = run_async(client.fetch_recently_played())
+            .expect_err("invalid recently played JSON should fail to parse");
+
+        assert!(format!("{:#}", err).contains("Failed to parse recently played"));
+    }
+
+    #[test]
     fn test_fetch_stats_builds_success_response_from_api_data() {
         let _guard = crate::test_support::lock_env();
         let cache_root = unique_temp_root("fetch-stats-success-cache");

--- a/src/steam/native.rs
+++ b/src/steam/native.rs
@@ -393,6 +393,29 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_games_xml_recovers_after_malformed_game_tag() {
+        let xml = "<games><game>broken<game>480</game><game>730</game></games>";
+        assert_eq!(parse_games_xml(xml), vec![730]);
+    }
+
+    #[test]
+    fn test_parse_games_xml_preserves_ordered_edge_cases() {
+        [
+            (
+                "<games><game>10</game><game>20</game><game>10</game></games>",
+                vec![10, 20, 10],
+            ),
+            (
+                r#"<games><game data-id="x">30</game><games><game>40</game></games>"#,
+                vec![30, 40],
+            ),
+            ("noise <game>50</game> tail <game>60</game>", vec![50, 60]),
+        ]
+        .into_iter()
+        .for_each(|(xml, expected)| assert_eq!(parse_games_xml(xml), expected));
+    }
+
+    #[test]
     fn test_parse_games_xml_multiple_games_wrappers_handled() {
         // Two `<games>` wrappers in sequence should both be skipped
         // without producing spurious entries.

--- a/src/steam/native.rs
+++ b/src/steam/native.rs
@@ -406,6 +406,7 @@ mod tests {
         use std::env;
         use std::fs;
         use std::path::{Path, PathBuf};
+        use std::process::Command;
         use std::time::{SystemTime, UNIX_EPOCH};
 
         struct HomeScope {
@@ -598,6 +599,38 @@ mod tests {
                 .find(|p| p.exists())
         }
 
+        fn write_null_create_interface_lib(target: &Path) {
+            fs::create_dir_all(target.parent().unwrap()).unwrap();
+            let source = target.with_extension("rs");
+            fs::write(
+                &source,
+                r#"
+#[no_mangle]
+pub unsafe extern "C" fn CreateInterface(
+    _: *const std::os::raw::c_char,
+    _: *mut i32,
+) -> *mut std::os::raw::c_void {
+    std::ptr::null_mut()
+}
+"#,
+            )
+            .unwrap();
+
+            let rustc = env::var("RUSTC").unwrap_or_else(|_| "rustc".to_string());
+            let output = Command::new(rustc)
+                .arg("--crate-type=cdylib")
+                .arg(&source)
+                .arg("-o")
+                .arg(target)
+                .output()
+                .expect("rustc should run");
+            assert!(
+                output.status.success(),
+                "rustc failed: {}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+
         #[test]
         fn test_try_new_returns_none_when_create_interface_symbol_missing() {
             // `Library::new` succeeds (we symlink to a real, loadable system
@@ -624,6 +657,22 @@ mod tests {
                 .expect("symlink to system lib should succeed in tmp dir");
 
             assert!(NativeSteamClient::try_new(false).is_none());
+
+            let _ = fs::remove_dir_all(&root);
+        }
+
+        #[test]
+        fn test_try_new_returns_none_when_create_interface_returns_null() {
+            // A tiny fake steamclient.so exports CreateInterface but returns a
+            // null pointer. That reaches the null-client branch after dlopen and
+            // symbol lookup both succeed, without calling any Steamworks APIs.
+            let _guard = lock_env();
+            let root = unique_root("create-iface-null");
+            let _scope = HomeScope::set(&root);
+            let target = root.join(".steam/sdk64/steamclient.so");
+            write_null_create_interface_lib(&target);
+
+            assert!(NativeSteamClient::try_new(true).is_none());
 
             let _ = fs::remove_dir_all(&root);
         }

--- a/src/steam/native.rs
+++ b/src/steam/native.rs
@@ -325,6 +325,14 @@ fn parse_games_xml(xml: &str) -> Vec<u32> {
 mod tests {
     use super::*;
 
+    fn run_async<F: std::future::Future>(f: F) -> F::Output {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("rt")
+            .block_on(f)
+    }
+
     #[test]
     fn test_parse_games_xml() {
         let xml = r#"<?xml version="1.0"?><games><game>220</game><game>240</game><game type="junk">480</game></games>"#;
@@ -397,6 +405,70 @@ mod tests {
         // Larger than u32::MAX — parse fails, entry skipped.
         let xml = "<games><game>9999999999999</game><game>20</game></games>";
         assert_eq!(parse_games_xml(xml), vec![20]);
+    }
+
+    #[test]
+    fn test_fetch_all_game_appids_propagates_fetch_error() {
+        use crate::test_support::lock_env;
+        use std::env;
+
+        const PROXY_VARS: &[&str] = &[
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ];
+
+        struct EnvScope {
+            saved: Vec<(&'static str, Option<String>)>,
+        }
+
+        impl EnvScope {
+            fn set_unreachable_proxy(url: &str) -> Self {
+                let saved = PROXY_VARS
+                    .iter()
+                    .map(|&key| {
+                        let prev = env::var(key).ok();
+                        env::remove_var(key);
+                        (key, prev)
+                    })
+                    .collect();
+
+                env::set_var("HTTPS_PROXY", url);
+                env::set_var("https_proxy", url);
+                env::set_var("NO_PROXY", "127.0.0.1,localhost");
+                env::set_var("no_proxy", "127.0.0.1,localhost");
+
+                Self { saved }
+            }
+        }
+
+        impl Drop for EnvScope {
+            fn drop(&mut self) {
+                for (key, value) in &self.saved {
+                    match value {
+                        Some(v) => env::set_var(key, v),
+                        None => env::remove_var(key),
+                    }
+                }
+            }
+        }
+
+        let _guard = lock_env();
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local addr");
+        drop(listener);
+        let _scope = EnvScope::set_unreachable_proxy(&format!("http://{}", addr));
+
+        let err = run_async(fetch_all_game_appids())
+            .expect_err("unreachable HTTPS proxy should make games.xml fetch fail");
+        let msg = format!("{:#}", err);
+        assert!(
+            msg.contains("Failed to fetch games.xml"),
+            "expected fetch context, got: {msg}",
+        );
     }
 
     #[cfg(target_os = "linux")]

--- a/src/steam/native.rs
+++ b/src/steam/native.rs
@@ -767,6 +767,7 @@ pub unsafe extern "C" fn CreateInterface(
 
             assert_eq!(client.steam_id(), 0);
             assert_eq!(client.username(), "Unknown");
+            assert!(client.get_owned_appids(&[]).is_empty());
         }
 
         #[test]

--- a/src/steam/native.rs
+++ b/src/steam/native.rs
@@ -678,6 +678,26 @@ pub unsafe extern "C" fn CreateInterface(
         }
 
         #[test]
+        fn test_null_native_handles_return_fallback_values() {
+            let Some(real_lib) = find_loadable_system_lib() else {
+                return;
+            };
+            let lib = unsafe { Library::new(real_lib).expect("system library should load") };
+            let client = std::mem::ManuallyDrop::new(NativeSteamClient {
+                _lib: lib,
+                client: std::ptr::null_mut(),
+                pipe: 0,
+                user: 0,
+                apps: std::ptr::null_mut(),
+                friends: std::ptr::null_mut(),
+                steam_user: std::ptr::null_mut(),
+            });
+
+            assert_eq!(client.steam_id(), 0);
+            assert_eq!(client.username(), "Unknown");
+        }
+
+        #[test]
         fn test_try_new_returns_none_when_create_interface_symbol_missing_verbose() {
             // Same CreateInterface-missing path with verbose=true — exercises
             // both the "Found Steam client at" log and the "Failed to get

--- a/src/steam/native.rs
+++ b/src/steam/native.rs
@@ -325,6 +325,50 @@ fn parse_games_xml(xml: &str) -> Vec<u32> {
 mod tests {
     use super::*;
 
+    const PROXY_VARS: &[&str] = &[
+        "HTTPS_PROXY",
+        "https_proxy",
+        "ALL_PROXY",
+        "all_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ];
+
+    struct EnvScope {
+        saved: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvScope {
+        fn set_unreachable_proxy(url: &str) -> Self {
+            let saved = PROXY_VARS
+                .iter()
+                .map(|&key| {
+                    let prev = std::env::var(key).ok();
+                    std::env::remove_var(key);
+                    (key, prev)
+                })
+                .collect();
+
+            std::env::set_var("HTTPS_PROXY", url);
+            std::env::set_var("https_proxy", url);
+            std::env::set_var("NO_PROXY", "127.0.0.1,localhost");
+            std::env::set_var("no_proxy", "127.0.0.1,localhost");
+
+            Self { saved }
+        }
+    }
+
+    impl Drop for EnvScope {
+        fn drop(&mut self) {
+            for (key, value) in &self.saved {
+                match value {
+                    Some(v) => std::env::set_var(key, v),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+
     fn run_async<F: std::future::Future>(f: F) -> F::Output {
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -433,51 +477,6 @@ mod tests {
     #[test]
     fn test_fetch_all_game_appids_propagates_fetch_error() {
         use crate::test_support::lock_env;
-        use std::env;
-
-        const PROXY_VARS: &[&str] = &[
-            "HTTPS_PROXY",
-            "https_proxy",
-            "ALL_PROXY",
-            "all_proxy",
-            "NO_PROXY",
-            "no_proxy",
-        ];
-
-        struct EnvScope {
-            saved: Vec<(&'static str, Option<String>)>,
-        }
-
-        impl EnvScope {
-            fn set_unreachable_proxy(url: &str) -> Self {
-                let saved = PROXY_VARS
-                    .iter()
-                    .map(|&key| {
-                        let prev = env::var(key).ok();
-                        env::remove_var(key);
-                        (key, prev)
-                    })
-                    .collect();
-
-                env::set_var("HTTPS_PROXY", url);
-                env::set_var("https_proxy", url);
-                env::set_var("NO_PROXY", "127.0.0.1,localhost");
-                env::set_var("no_proxy", "127.0.0.1,localhost");
-
-                Self { saved }
-            }
-        }
-
-        impl Drop for EnvScope {
-            fn drop(&mut self) {
-                for (key, value) in &self.saved {
-                    match value {
-                        Some(v) => env::set_var(key, v),
-                        None => env::remove_var(key),
-                    }
-                }
-            }
-        }
 
         let _guard = lock_env();
         let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
@@ -492,6 +491,36 @@ mod tests {
             msg.contains("Failed to fetch games.xml"),
             "expected fetch context, got: {msg}",
         );
+    }
+
+    #[test]
+    fn test_fetch_all_game_appids_proxy_scope_restores_previous_values() {
+        use crate::test_support::lock_env;
+        use std::env;
+
+        let _guard = lock_env();
+        let original: Vec<(&'static str, Option<String>)> = PROXY_VARS
+            .iter()
+            .map(|&key| (key, env::var(key).ok()))
+            .collect();
+        env::set_var("HTTPS_PROXY", "http://proxy-sentinel.invalid:9");
+
+        {
+            let _scope = EnvScope::set_unreachable_proxy("http://127.0.0.1:9");
+            assert_eq!(env::var("HTTPS_PROXY").unwrap(), "http://127.0.0.1:9");
+        }
+
+        assert_eq!(
+            env::var("HTTPS_PROXY").unwrap(),
+            "http://proxy-sentinel.invalid:9"
+        );
+
+        for (key, value) in original {
+            match value {
+                Some(v) => env::set_var(key, v),
+                None => env::remove_var(key),
+            }
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -11,3 +11,22 @@ static ENV_LOCK: Mutex<()> = Mutex::new(());
 pub fn lock_env() -> MutexGuard<'static, ()> {
     ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_env_recovers_from_poisoned_mutex() {
+        let previous_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| {}));
+        let result = std::panic::catch_unwind(|| {
+            let _guard = ENV_LOCK.lock().unwrap();
+            panic!("poison ENV_LOCK");
+        });
+        std::panic::set_hook(previous_hook);
+
+        assert!(result.is_err());
+        let _guard = lock_env();
+    }
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -59,3 +59,27 @@ fn demo_flag_renders_demo_profile_without_config() {
     assert!(stdout.contains("Games:"));
     assert!(stdout.contains("Top Played"));
 }
+
+#[test]
+fn invalid_config_exits_before_network_request() {
+    let root = unique_temp_root("invalid-config");
+    std::fs::create_dir_all(&root).unwrap();
+    let config = root.join("config.toml");
+    std::fs::write(&config, "this is = not [valid toml").unwrap();
+
+    let output = Command::new(binary())
+        .arg("--config")
+        .arg(&config)
+        .env("HOME", &root)
+        .output()
+        .expect("steamfetch should run");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+
+    assert!(!output.status.success());
+    assert!(stdout.is_empty());
+    assert!(stderr.contains("Failed to parse config file"));
+
+    let _ = std::fs::remove_dir_all(&root);
+}

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,61 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_steamfetch"))
+}
+
+fn unique_temp_root(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    std::env::temp_dir().join(format!(
+        "steamfetch-cli-test-{}-{}-{}",
+        label,
+        std::process::id(),
+        nanos
+    ))
+}
+
+#[test]
+fn config_path_flag_prints_config_path_and_exits() {
+    let root = unique_temp_root("config-path");
+    std::fs::create_dir_all(&root).unwrap();
+
+    let output = Command::new(binary())
+        .arg("--config-path")
+        .env("XDG_CONFIG_HOME", &root)
+        .output()
+        .expect("steamfetch should run");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    let printed = PathBuf::from(stdout.trim());
+
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(printed.ends_with(Path::new("steamfetch").join("config.toml")));
+    assert!(
+        stderr.is_empty(),
+        "--config-path should not print diagnostics on success"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+}
+
+#[test]
+fn demo_flag_renders_demo_profile_without_config() {
+    let output = Command::new(binary())
+        .arg("--demo")
+        .output()
+        .expect("steamfetch should run");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+
+    assert!(output.status.success(), "stderr: {stderr}");
+    assert!(stdout.contains("unhappychoice@Steam"));
+    assert!(stdout.contains("Games:"));
+    assert!(stdout.contains("Top Played"));
+}


### PR DESCRIPTION
Measure line coverage, pick one untested piece of real logic at a time, and add tests for it.
Re-measure to confirm overall line coverage increases.
All changes go through the test suite, linter, and formatter before being applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for configuration handling, cache persistence, display rendering, and image fallback behavior.
  * Added integration tests for CLI operations including config path resolution and demo mode.
  * Enhanced test infrastructure for Steam client and native client operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->